### PR TITLE
Patch to use schema ldif file

### DIFF
--- a/test/integration/BasicTests.groovy
+++ b/test/integration/BasicTests.groovy
@@ -89,6 +89,29 @@ objectClass: organizationalPerson
 		assertTrue(d2LdapServer.exists("cn=cn3,dc=d2"))
 	}
 	
+	void testLoadSchemaLdif() {
+		d2LdapServer.loadLdif("""
+dn: cn=schema
+changetype: modify
+add: attributetypes
+attributetypes: ( 1.3.6.1.4.1.99999.2.1.0.0 NAME 'myRegionalOffice' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
+-
+add: objectclasses
+objectclasses: (  1.3.6.1.4.1.99999.2.3.1.0.0  NAME 'myUser' SUP 'person' STRUCTURAL MAY ( myRegionalOffice ) )
+-
+""")
+		d2LdapServer.loadLdif("""
+dn: cn=cn3,dc=d2
+cn: cn3
+sn: sn
+objectClass: person
+objectClass: top
+objectClass: myUser
+myRegionalOffice: nowhere
+""")
+		assertTrue(d2LdapServer.exists("cn=cn3,dc=d2"))
+	}
+	
 	void testClean() {
 		d2LdapServer.loadFixture("testou")
 		assertTrue(d2LdapServer.exists("ou=test,dc=d2"))


### PR DESCRIPTION
## Problem

When you add a schema ldif fill under 

> grails-app/ldap-server/<name>/schema

you get a exception

> The global schema subentry cannot be added since it exists by default.
## Cause:

t's because the parsed ldif is used to do an add operation.

``` java
    private consumeLdifReader(ldifReader) {
        while (ldifReader.hasNext()) {
            def entry = ldifReader.next()
            def ldif = LdifUtils.convertToLdif(entry, Integer.MAX_VALUE)
            directoryService.adminSession.add(directoryService.newEntry(ldif, entry.dn.toString()))
        }
    }
```
## Fix

You have to modify cn=schema because it exist and use CoreSession.modify(..) instead of add(..)

``` java
    private consumeLdifReader(ldifReader) {
        while (ldifReader.hasNext()) {
            LdifEntry entry = ldifReader.next()
            if ( entry.isChangeModify() ) {
                directoryService.adminSession.modify(entry.dn, entry.modificationList)
            } else {
                def ldif = LdifUtils.convertToLdif(entry, Integer.MAX_VALUE)
                directoryService.adminSession.add(directoryService.newEntry(ldif, entry.dn.toString()))
            }
        }
    }
```
## Unit test

``` java
    void testLoadSchemaLdif() {
        d2LdapServer.loadLdif("""
dn: cn=schema
changetype: modify
add: attributetypes
attributetypes: ( 1.3.6.1.4.1.99999.2.1.0.0 NAME 'myRegionalOffice' EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX '1.3.6.1.4.1.1466.115.121.1.15' )
-
add: objectclasses
objectclasses: (  1.3.6.1.4.1.99999.2.3.1.0.0  NAME 'myUser' SUP 'person' STRUCTURAL MAY ( myRegionalOffice ) )
-
""")
        d2LdapServer.loadLdif("""
dn: cn=cn3,dc=d2
cn: cn3
sn: sn
objectClass: person
objectClass: top
objectClass: myUser
myRegionalOffice: nowhere
""")
        assertTrue(d2LdapServer.exists("cn=cn3,dc=d2"))
    }
```
